### PR TITLE
Fix MKL conflict and use multiple MATLAB / Python combinations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
   global:
     - PYENV_RELEASE=1.2.21
 
+jobs:
+  exclude:
+    - matlab: R2020a
+      env: PYTHON_VERSION=3.8.6
+
 before_install:
   # Update pyenv
   - pushd $(pyenv root)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,37 @@
-
+dist: xenial
+env:
+  global:
+    - PATH=/opt/python/3.7.1/bin:$PATH
 language: matlab
-install:
-  # We do this conditionally because it saves us some downloading if the version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - source "$HOME/miniconda/etc/profile.d/conda.sh"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
+install:  
+  # Check the python version and update pip
+  - python -V
+  - python -m pip install --upgrade pip
   
-  # Add Conda Forge to conda environment
-  - conda config --append channels conda-forge 
-  # - conda config --add channels intel
-  # Add dependencies to conda environment and specify python 3.8
-  - conda create -q -n test-environment python=3.8 pandas scipy matplotlib requests 
-  # install pip
-  - conda install pip
-  # - python -m pip install --upgrade pip wheel
-  # activate the conda environement
-  - conda activate test-environment
-  - python setup.py install
-
-  # install pecos
-  - python -m pip install pecos
+  # Install MHKiT-Python
+  - python -m pip install mhkit
   
-  # install libpng. If it is outdated, it could cause error with the updated matplotlib package
-  - sudo apt-get install libpng-dev
-  
-  # update matplotlib to get rid of errors with libpng and zlib
-  - python -m pip install --upgrade matplotlib sklearn pandas scipy requests numpy
-  # python -m pip install --upgrade sklearn
-  # python -m pip install --upgrade pandas
-  # python -m pip install --upgrade scipy
-  # - python -m pip install numpy==1.17.2
-
-  # Install mhkit-python
-  - git clone --depth 1 https://github.com/MHKiT-Software/MHKiT-Python mhkit-python
-  - cd mhkit-python
-  - python -m pip install -e .
-  - cd ..
+  # Install MHKiT-MATLAB
   - python -m pip install -e .
 
 script:
-  # shows matlab version for the build
-  - matlab -batch "version"
-  - matlab -batch "pyversion"
-  - matlab -batch "py.sys.setdlopenflags(int32(10))"
-  # installs mhkit toolbox in matlab, goes to test folder to the script that runs all the tests, imports mhkit, then runs the test script
-  - matlab -batch  "matlab.addons.toolbox.installToolbox('/home/travis/build/mfaltas-sandia/MHKiT-MATLAB/mhkit.mltbx'), cd mhkit/tests/ , import mhkit.*, results = runTests(), assertSuccess(results)"
+  # Look for linalg
+  - ls /opt/python/3.7.1/lib/python3.7/site-packages/numpy/linalg/
+  
+  # Try and preload numpy lapack
+  #- export LD_LIBRARY_PATH=/opt/python/3.7.1/lib
+  #- export LD_PRELOAD=/opt/python/3.7.1/lib/python3.7/site-packages/numpy/linalg/lapack_lite.cpython-37m-x86_64-linux-gnu.so
+
+  # Show matlab and python version for the build
+  - matlab -batch "py.sys.setdlopenflags(int32(10)), version, pyversion, version('-blas')"
+  
+  # Installs mhkit toolbox in matlab, goes to the test folder, imports mhkit, 
+  # then runs the test script
+  - >
+    matlab -batch 
+    "py.sys.setdlopenflags(int32(10)),
+    matlab.addons.toolbox.installToolbox('mhkit.mltbx'),
+    cd mhkit/tests/,
+    import mhkit.*,
+    results = runTests(),
+    assertSuccess(results)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,28 @@
-dist: xenial
-env:
-  global:
-    - PATH=/opt/python/3.7.1/bin:$PATH
 language: matlab
+
+matlab:
+  - R2020a
+  - latest  # Default MATLAB release on Travis CI
+
+env:
+  jobs:
+    - PYTHON_VERSION=3.6.12
+    - PYTHON_VERSION=3.7.9
+    - PYTHON_VERSION=3.8.6
+  global:
+    - PYENV_RELEASE=1.2.21
+
+before_install:
+  # Update pyenv
+  - pushd $(pyenv root)
+  - git fetch
+  - git checkout v${PYENV_RELEASE}
+  - popd
+
 install:  
-  # Check the python version and update pip
-  - python -V
+  # Install the python version and update pip
+  - pyenv install -v ${PYTHON_VERSION}
+  - pyenv global ${PYTHON_VERSION}
   - python -m pip install --upgrade pip
   
   # Install MHKiT-Python
@@ -15,13 +32,6 @@ install:
   - python -m pip install -e .
 
 script:
-  # Look for linalg
-  - ls /opt/python/3.7.1/lib/python3.7/site-packages/numpy/linalg/
-  
-  # Try and preload numpy lapack
-  #- export LD_LIBRARY_PATH=/opt/python/3.7.1/lib
-  #- export LD_PRELOAD=/opt/python/3.7.1/lib/python3.7/site-packages/numpy/linalg/lapack_lite.cpython-37m-x86_64-linux-gnu.so
-
   # Show matlab and python version for the build
   - matlab -batch "py.sys.setdlopenflags(int32(10)), version, pyversion, version('-blas')"
   


### PR DESCRIPTION
This commit fixes the issue with the MATLAB and numpy LAPACK versions conflicting using the method proposed [here](https://uk.mathworks.com/matlabcentral/answers/327193-calling-python-module-from-matlab-causes-segmentation-fault-in-h5py#answer_296569). It also turns out Anaconda does not play nicely with MATLAB either, as MATLAB sets LD_LIBRARY_PATH, which is bad for conda environments.

To move away from Anaconda, this commit uses pyenv to explicitly build Python versions (Travis' preferred method). This allows testing with multiple Python and MATLAB versions.

Note there might be an issue with running all these tests in parallel as they might be putting too many requests into the data services and being denied.